### PR TITLE
Fix deprecation warning in goreleaser.

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -65,7 +65,7 @@ checksum:
     - glob: ./dist/*-darwin-amd64.zip
     - glob: ./dist/*-darwin-arm64.zip
 brews:
-  - tap:
+  - repository:
       owner: conductorone
       name: homebrew-baton
     folder: Formula


### PR DESCRIPTION
"tap" has been replaced with "repository"
https://goreleaser.com/deprecations/#__tabbed_7_1