### PR TITLE
Fetch page access levels for a group once instead of re-fetching for every member of a group.

### DIFF
--- a/pkg/connector/pages.go
+++ b/pkg/connector/pages.go
@@ -173,15 +173,15 @@ func (s *pageSyncer) Grants(ctx context.Context, resource *v2.Resource, pToken *
 			return nil, "", nil, err
 		}
 
+		pageAccessLevels, err := s.pageAccessLevelsForGroup(ctx, page, group)
+		if err != nil {
+			return nil, "", nil, err
+		}
+
 		for _, m := range members {
 			if m.GetUserID() == 0 {
 				l.Debug("member did not have user ID defined -- skipping")
 				continue
-			}
-
-			pageAccessLevels, err := s.pageAccessLevelsForGroup(ctx, page, group)
-			if err != nil {
-				return nil, "", nil, err
 			}
 
 			principalID := &v2.ResourceId{


### PR DESCRIPTION
This was just a little inefficient.