### PR TITLE
fix: grant group

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -72,7 +72,6 @@ linters:
     - bodyclose # checks whether HTTP response body is closed successfully
     - durationcheck # check for two durations multiplied together
     - errorlint # errorlint is a linter for that can be used to find code that will cause problems with the error wrapping scheme introduced in Go 1.13.
-    - execinquery # execinquery is a linter about query string checker in Query function which reads your Go src files and warning it finds
     - exhaustive # check exhaustiveness of enum switch statements
     - exportloopref # checks for pointers to enclosing loop variables
     - forbidigo # Forbids identifiers

--- a/pkg/client/group.go
+++ b/pkg/client/group.go
@@ -279,11 +279,7 @@ func (c *Client) GetGroupMember(ctx context.Context, groupID, userID int64) (*Gr
 	args = append(args, userID)
 
 	sb := &strings.Builder{}
-	_, err := sb.WriteString(`SELECT "id", "userId", "groupId", "isAdmin" FROM user_groups WHERE "groupId"=$1 AND "userId"=$2`)
-	if err != nil {
-		return nil, err
-	}
-	_, err = sb.WriteString("LIMIT 1")
+	_, err := sb.WriteString(`SELECT "id", "userId", "groupId", "isAdmin" FROM user_groups WHERE "groupId"=$1 AND "userId"=$2 LIMIT 1`)
 	if err != nil {
 		return nil, err
 	}
@@ -309,13 +305,8 @@ func (c *Client) AddGroupMember(ctx context.Context, groupID, userID int64, isAd
 	l.Debug("add user to group", zap.Int64("user_id", userID))
 
 	args := []interface{}{groupID, userID, isAdmin}
-	sb := &strings.Builder{}
-	_, err := sb.WriteString(`INSERT INTO user_groups ("groupId", "userId", "isAdmin", "createdAt", "updatedAt") VALUES ($1, $2, $3, NOW(), NOW())`)
-	if err != nil {
-		return err
-	}
 
-	if _, err := c.db.Exec(ctx, sb.String(), args...); err != nil {
+	if _, err := c.db.Exec(ctx, `INSERT INTO user_groups ("groupId", "userId", "isAdmin", "createdAt", "updatedAt") VALUES ($1, $2, $3, NOW(), NOW())`, args...); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Fix grant group

GetGroupMember had an issue when concat strings on String Builder without a space after the $2 argument

Also removed deprecated linter to fix the ci