### PR TITLE
Skip optional fields and fields with default values when inserting into groups

### DIFF
--- a/pkg/client/group.go
+++ b/pkg/client/group.go
@@ -291,7 +291,8 @@ func (c *Client) CreateGroup(ctx context.Context, organizationID *int64, name st
 
 	args := []interface{}{name, organizationID}
 
-	if _, err := c.db.Exec(ctx, `INSERT INTO groups ("name", "organizationId", "createdAt", "updatedAt", "archivedAt", "usageAnalyticsAccess", "themeAccess", "unpublishedReleaseAccess", "accountDetailsAccess") VALUES ($1, $2,NOW(), NOW(), NULL, false, false, false, false)`, args...); err != nil {
+	if _, err := c.db.Exec(ctx, `INSERT INTO groups ("name", "organizationId", "createdAt", "updatedAt") 
+		VALUES ($1, $2, NOW(), NOW())`, args...); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Growtherapy had an error with provisioning apps `column themeAccess of relation "groups" does not exist` so I removed all the optional fields and fields with default values

```
         column_name         | is_nullable |        data_type         |           column_default           
-----------------------------+-------------+--------------------------+------------------------------------
 id                          | NO          | integer                  | nextval('groups_id_seq'::regclass)
 name                        | NO          | character varying        | 
 organizationId              | YES         | integer                  | 
 createdAt                   | NO          | timestamp with time zone | 
 updatedAt                   | NO          | timestamp with time zone | 
 universalAccess             | NO          | character varying        | 'none'::character varying
 universalResourceAccess     | NO          | character varying        | 'none'::character varying
 universalQueryLibraryAccess | NO          | character varying        | 'none'::character varying
 userListAccess              | NO          | boolean                  | false
 archivedAt                  | YES         | timestamp with time zone | 
 auditLogAccess              | NO          | boolean                  | false
 unpublishedReleaseAccess    | NO          | boolean                  | true
 universalWorkflowAccess     | NO          | character varying        | 'none'::character varying
 usageAnalyticsAccess        | YES         | boolean                  | 
 accountDetailsAccess        | NO          | boolean                  | true
 themeAccess                 | YES         | boolean                  | 
 ```

<img width="1291" alt="image" src="https://github.com/user-attachments/assets/77a924e9-bed9-4def-a887-4371ab400ecb" />

<img width="1273" alt="image" src="https://github.com/user-attachments/assets/2233a0d9-fc1b-4add-af61-e71f064db2b0" />


<img width="1247" alt="image" src="https://github.com/user-attachments/assets/fa21159e-836f-41db-b9d8-6e479f4efc48" />

