### PR TITLE
Also grant expand user access.

### DIFF
--- a/pkg/connector/pages.go
+++ b/pkg/connector/pages.go
@@ -197,9 +197,10 @@ func (s *pageSyncer) Grants(ctx context.Context, resource *v2.Resource, pToken *
 				},
 			}
 
-			newGrant := grant.NewGrant(resource, fmt.Sprintf("%s:%s", "group", level), groupId, grant.WithAnnotation(grantExpandable))
+			newGroupGrant := grant.NewGrant(resource, fmt.Sprintf("%s:%s", "group", level), groupId, grant.WithAnnotation(grantExpandable))
+			newUserGrant := grant.NewGrant(resource, fmt.Sprintf("%s:%s", "user", level), groupId, grant.WithAnnotation(grantExpandable))
 
-			ret = append(ret, newGrant)
+			ret = append(ret, newGroupGrant, newUserGrant)
 		}
 
 		bag.Pop()


### PR DESCRIPTION
With out this change, if access was provisioned via a user entitlement, that user entitlement will be moved to a group assignment, because that's how the access is actually determined at sync time. With this fix, no matter how you got the access you will now both have a user and a group entitlement for that access to an app. Only the user one is requestable. I am not aware of a workaround