### PR TITLE
docs: add BATON_PROVISIONING flag to Kubernetes secrets config

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -138,6 +138,9 @@ stringData:
   
   # Retool credentials
   BATON_CONNECTION_STRING: <The Retool connection string, in format "user=baton password=secure-password host=localhost port=5432 dbname=hammerhead_production">
+
+  # Optional: include if you want C1 to provision access using this connector
+  BATON_PROVISIONING: true
 ```
 
 See the connector's README or run `--help` to see all available configuration flags and environment variables.


### PR DESCRIPTION
## Summary

The `docs/connector.mdx` Kubernetes secrets configuration was missing `BATON_PROVISIONING: true`. Added the flag with the standard explanatory comment to match the pattern used in other provisioning-capable connector docs.

This mirrors the fix applied to the main ConductorOne/docs site in PR #245.