### PR TITLE
[CXH-2015] - Return InvalidArgument instead of panicking on empty resource_id in enable_user/disable_user

### DIFF
--- a/pkg/connector/helpers.go
+++ b/pkg/connector/helpers.go
@@ -13,6 +13,9 @@ func formatObjectID(resourceTypeID string, id int64) string {
 }
 
 func parseObjectID(id string) (int64, error) {
+	if len(id) < 2 {
+		return 0, fmt.Errorf("invalid resource id: %q", id)
+	}
 	return strconv.ParseInt(id[1:], 10, 64)
 }
 

--- a/pkg/connector/helpers_test.go
+++ b/pkg/connector/helpers_test.go
@@ -1,0 +1,28 @@
+package connector
+
+import "testing"
+
+func TestParseObjectID(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantID  int64
+		wantErr bool
+	}{
+		{"empty string", "", 0, true},
+		{"single char prefix only", "u", 0, true},
+		{"valid user id", "u12345", 12345, false},
+		{"invalid non-numeric suffix", "uabc", 0, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseObjectID(tc.input)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("parseObjectID(%q) error = %v, wantErr %v", tc.input, err, tc.wantErr)
+			}
+			if !tc.wantErr && got != tc.wantID {
+				t.Fatalf("parseObjectID(%q) = %d, want %d", tc.input, got, tc.wantID)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes CXH-2015

The `enable_user`/`disable_user` global actions validated the `user_id` argument's resource type but not its resource ID. An empty `resource_id` reached `parseObjectID`, which performs `id[1:]` with no length check, causing a slice-bounds-out-of-range panic. The SDK's action framework recovers the panic, but the action failed with a raw panic string instead of a clean `InvalidArgument` status.

## Changes

- **`pkg/connector/helpers.go`**: Added a `len(id) < 2` guard in `parseObjectID` that returns `fmt.Errorf("invalid resource id: %q", id)` instead of panicking. The existing error-handling in `setUserActive` already converts this into an `InvalidArgument` gRPC status — no change to `actions.go` was needed.
- **`pkg/connector/helpers_test.go`**: New test file covering `parseObjectID` with empty string, single-char string, valid ID, and invalid format — all four cases pass without panicking.

## Repro Steps

1. Configure the connector with a valid Retool instance.
2. Trigger the `enable_user` or `disable_user` action with a `user_id` argument whose `resource_id` field is empty.
3. **Before fix**: action fails with a raw panic string (`slice bounds out of range [1:0]`).
4. **After fix**: action returns a clean `InvalidArgument` status with the message `baton-retool: invalid user_id "": invalid resource id: ""`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)